### PR TITLE
ログイン前のフッターとログイン後のフッターに分けた

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -33,7 +33,7 @@ class ProfilesController < ApplicationController
   def show
     @profile = Profile.find(params[:id])
     @user = @profile.user  # プロフィール所有者のユーザーを取得
-    @oshi_details = @profile.fetch_oshi_details.page(params[:page]).per(2) # 推しの詳細情報を取得
+    @oshi_details = @profile.fetch_oshi_details.page(params[:page]).per(5) # 推しの詳細情報を取得
   end
 
   def my_articles

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,8 +18,14 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
+    
     <%= render 'shared/flash_message' %>
     <%= yield %>
-    <%= render 'shared/footer' %>
+
+    <% if logged_in? %>
+      <%= render 'shared/footer' %>
+    <% else %>
+      <%= render 'shared/before_login_footer' %>
+    <% end %>
   </body>
 </html>

--- a/app/views/shared/_before_login_footer.html.erb
+++ b/app/views/shared/_before_login_footer.html.erb
@@ -1,0 +1,10 @@
+<footer class="footer bg-base-300 fixed bottom-0 text-ghost-content p-5 flex flex-col items-center">
+  <div class="flex justify-center space-x-5">
+    <a class="link link-hover">プライバシーリテラシー</a>
+    <a class="link link-hover">利用規約</a>
+    <a class="link link-hover">お問い合わせフォーム</a>
+  </div>
+  <div class="text-center">
+    <p>Copyright@ 2024 推しOPEN</p>
+  </div>
+</footer>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -2,13 +2,15 @@
   <div class="flex-1">
     <%= link_to "推しOPEN", root_path, class: 'btn btn-ghost text-xl' %>
   </div>
+
+  <!-- PC版に関する記述 -->
   <div class="space-x-4 hidden lg:block">
     <%= link_to "記事一覧", articles_path, class: 'btn btn-neutral' %>
     <%= link_to "ログイン", login_path, class: 'btn btn-neutral' %>
     <%= link_to "新規作成", new_user_path, class: 'btn btn-neutral' %>
   </div>
 
-  <!-- サイドメニューに関する記述 -->
+  <!-- スマホ版のサイドメニューに関する記述 -->
   <div class="lg:hidden">
     <div class="drawer drawer-end">
       <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,10 +1,22 @@
-<footer class="footer bg-base-300 text-ghost-content p-5 flex flex-col items-center">
-  <div class="flex justify-center space-x-5">
-    <a class="link link-hover">プライバシーリテラシー</a>
-    <a class="link link-hover">利用規約</a>
-    <a class="link link-hover">お問い合わせフォーム</a>
-  </div>
-  <div class="text-center">
-    <p>Copyright@ 2024 推しOPEN</p>
-  </div>
+<footer class="footer bg-base-300 fixed bottom-0 flex justify-between w-full">
+  <%= link_to profile_path(current_user.profile), class: "flex flex-col items-center hover:bg-gray-300 flex-1 py-3" do %>
+    <i class="fa-sharp-duotone fa-solid fa-house"></i>
+    <p>マイページ</p>
+  <% end %>
+
+  <%= link_to articles_path, class: "flex flex-col items-center hover:bg-gray-300 flex-1 py-3" do %>
+    <i class="fa-sharp-duotone fa-solid fa-list"></i>
+    <p>記事一覧</p>
+  <% end %>
+
+  <%= link_to new_article_path, class: "flex flex-col items-center hover:bg-gray-300 flex-1 py-3" do %>
+    <i class="fa-sharp-duotone fa-solid fa-pen-to-square"></i>
+    <p>記事作成</p>
+  <% end %>
+
+  <%= link_to logout_path, data: { turbo_method: :delete }, class: "flex flex-col items-center hover:bg-gray-300 flex-1 py-3" do %>
+    <i class="fa-sharp-duotone fa-solid fa-right-from-bracket"></i>
+    <p>ログアウト</p>
+  <% end %>
+
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,11 +2,13 @@
   <div class="flex-1">
     <%= link_to "推しOPEN", root_path, class: 'btn btn-ghost text-xl' %>
   </div>
+
+  <!-- PC版に関する記述 -->
   <div class="space-x-4 hidden lg:flex items-center">
     <%= link_to "記事一覧", articles_path, class: 'btn btn-neutral' %>
     <%= link_to "記事作成", new_article_path, class: 'btn btn-neutral' %>
 
-    <!-- PC版のサイドメニューに関する記述 -->
+    <!-- サイドメニューに関する記述 -->
     <div class="drawer drawer-end">
       <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />
       <div class="drawer-content">


### PR DESCRIPTION
- _before_login_footer.html.erbを作成。内容は今までの_footer.html.erb
- _before_login_footer.html.erbは画面の下に固定
- _footer.html.erbをユーザーが使いやすいものに変更
- _footer.html.erbは画面の下に絶対に表示されるように設定。

### 設定する必要があること
- _footer.html.erbはメインの下の部分に被ってしまうので、そこを修正
