### PR TITLE
コメントの通知機能実装

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,10 @@
 class CommentsController < ApplicationController
   def create
+    @article = Article.find(params[:article_id])
     @comment = current_user.comments.build(create_comment_params)
-    @comment.save
+    if @comment.save
+      @article.create_notification_comment!(current_user, @comment.id)
+    end
   end
 
   def edit

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,8 @@
+class NotificationsController < ApplicationController
+  def index
+    @notifications = current_user.passive_notifications.page(params[:page]).per(20)
+    @notifications.where(checked: false).each do |notification|
+      notification.update_attribute(:checked, true)
+    end
+  end
+end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,5 @@
+module NotificationsHelper
+  def unchecked_notifications
+    @notifications = current_user.passive_notifications.where(checked: false)
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,6 +6,7 @@ class Article < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :article_tags, dependent: :destroy
   has_many :tags, through: :article_tags
+  has_many :notifications, dependent: :destroy
 
   has_rich_text :content
 
@@ -25,6 +26,29 @@ class Article < ApplicationRecord
 
   def self.ransackable_associations(auth_object = nil)
     %w[user oshi_name] # 関連モデルを指定して検索可能に
+  end
+
+  def create_notification_comment!(current_user, comment_id)
+    # 自分以外にコメントしている人をすべて取得し、全員に通知を送る
+    temp_ids = Comment.select(:user_id).where(article_id: id).where.not(user_id: current_user.id).distinct
+    temp_ids.each do |temp_id|
+      save_notification_comment!(current_user, comment_id, temp_id['user_id'])
+    end
+    # まだ誰もコメントしていない場合は、投稿者に通知を送る
+    save_notification_comment!(current_user, comment_id, user_id) if temp_ids.blank?
+  end
+
+  def save_notification_comment!(current_user, comment_id, visited_id)
+    # コメントは複数回することが考えられるため、１つの投稿に複数回通知する
+    notification = current_user.active_notifications.new(
+      article_id: id,
+      comment_id: comment_id,
+      visited_id: visited_id,
+      action: 'comment'
+    )
+    # 自分の投稿に対するコメントの場合は、通知済みとする
+    notification.checked = true if notification.visitor_id == notification.visited_id
+    notification.save if notification.valid?
   end
 
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,4 +3,6 @@ class Comment < ApplicationRecord
 
   belongs_to :user
   belongs_to :article
+  has_many :notifications, dependent: :destroy
+
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,6 @@
+class Notification < ApplicationRecord
+  belongs_to :visitor, class_name: "User"
+  belongs_to :visited, class_name: "User"
+  belongs_to :article, optional: true
+  belongs_to :comment, optional: true
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,4 +1,5 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: "User"
   belongs_to :followed, class_name: "User"
+  belongs_to :notifiable, polymorphic: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,10 +13,14 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :favorite_articles, through: :favorites, source: :article
+  # フォロー機能に関するアソシエーション
   has_many :active_relationships, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
   has_many :passive_relationships, class_name: "Relationship", foreign_key: "followed_id", dependent: :destroy
   has_many :following_users, through: :active_relationships, source: :followed
   has_many :follower_users, through: :passive_relationships, source: :follower
+  # 通知機能に関するアソシエーション
+  has_many :active_notifications, class_name: "Notification", foreign_key: "visitor_id", dependent: :destroy
+  has_many :passive_notifications, class_name: "Notification", foreign_key: "visited_id", dependent: :destroy
   # Google認証に関するアソシエーション
   has_many :authentications, :dependent => :destroy
   accepts_nested_attributes_for :authentications

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -6,7 +6,7 @@
           <div class="m-1">
             <div class="card bg-base-100 max-w-4xl shadow-xl">
               <div class="card-body">
-                <h3><%= comment.user.profile.name %></h3>
+                <h3><%= comment.user.name %></h3>
                 <h3>作成日：<%= l comment.created_at, format: :short %></h3>
                 <h3><%= comment.body %></h3>
                 <% if current_user&.own1?(comment) %>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,0 +1,17 @@
+<% visitor = notification.visitor %>
+<% visited = notification.visited %>
+<div class="m-1">
+  <div id="notification-id-<%= notification.id %>">
+    <div class="card bg-base-100 max-w-4xl mx-auto">
+      <div class="card-body">
+        <h2><%= link_to visitor.name, profile_path(visitor) %>さんが</h2>
+        <% case notification.action %>
+        <% when 'comment' %>
+          <% if notification.article.user_id == visited.id %>
+            <h2><%= link_to "あなたの投稿", notification.article %>にコメントしました</h2>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,0 +1,17 @@
+<div class="container mx-auto px-4 mb-36">
+  <div class="flex justify-center">
+    <div class="w-full max-w-5xl">
+      <h1 class="text-center text-3xl font-bold mt-10 mb-4">通知</h1>
+    
+      <div class="bg-base-200 min-h-3.5 p-2">
+      <% notifications = @notifications.where.not(visitor_id: current_user.id) %>
+        <% if @notifications.present? %>
+          <%= render partial: 'notification', collection: @notifications %>
+        <% else %>
+          <h1 class="text-center text-xl">通知まだありません</h1>
+        <% end %>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,17 +1,27 @@
 <footer class="footer bg-base-300 fixed bottom-0 flex justify-between w-full">
   <%= link_to profile_path(current_user.profile), class: "flex flex-col items-center hover:bg-gray-300 flex-1 py-3" do %>
-    <i class="fa-sharp-duotone fa-solid fa-house"></i>
+    <i class="fa-solid fa-house"></i>
     <p>マイページ</p>
   <% end %>
 
   <%= link_to articles_path, class: "flex flex-col items-center hover:bg-gray-300 flex-1 py-3" do %>
-    <i class="fa-sharp-duotone fa-solid fa-list"></i>
+    <i class="fa-solid fa-list"></i>
     <p>記事一覧</p>
   <% end %>
 
   <%= link_to new_article_path, class: "flex flex-col items-center hover:bg-gray-300 flex-1 py-3" do %>
-    <i class="fa-sharp-duotone fa-solid fa-pen-to-square"></i>
+    <i class="fa-solid fa-pen-to-square"></i>
     <p>記事作成</p>
+  <% end %>
+
+  <%= link_to notifications_path, class: "flex flex-col items-center hover:bg-gray-300 flex-1 py-3" do %>
+    <% if unchecked_notifications.any? %>
+      <i class="fa-solid fa-bell"></i>
+      <p>コメント通知</p>
+    <% else %>
+      <i class="fa-solid fa-bell-slash"></i>
+      <p>コメント通知</p>
+    <% end %>
   <% end %>
 
   <%= link_to logout_path, data: { turbo_method: :delete }, class: "flex flex-col items-center hover:bg-gray-300 flex-1 py-3" do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,4 +30,5 @@ Rails.application.routes.draw do
   post "oauth/callback" => "oauths#callback"
   get "oauth/callback" => "oauths#callback" 
   get "oauth/:provider" => "oauths#oauth", :as => :auth_at_provider
+  resources :notifications, only: %i[index]
 end

--- a/db/migrate/20241107120623_create_notifications.rb
+++ b/db/migrate/20241107120623_create_notifications.rb
@@ -1,0 +1,15 @@
+class CreateNotifications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :notifications do |t|
+      t.references :visitor, null: false, foreign_key: { to_table: :users }
+      t.references :visited, null: false, foreign_key: { to_table: :users }
+      t.references :article, null: true, foreign_key: true
+      t.references :comment, null: true, foreign_key: true
+      t.string :action, null: false, default: ''
+      t.boolean :checked, null: false, default: false
+
+      t.timestamps
+    end
+    add_index :notifications, [:visitor_id, :visited_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_02_103324) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_07_120623) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -102,6 +102,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_02_103324) do
     t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
+  create_table "notifications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "visitor_id", null: false
+    t.bigint "visited_id", null: false
+    t.bigint "article_id"
+    t.bigint "comment_id"
+    t.string "action", default: "", null: false
+    t.boolean "checked", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id"], name: "index_notifications_on_article_id"
+    t.index ["comment_id"], name: "index_notifications_on_comment_id"
+    t.index ["visited_id"], name: "index_notifications_on_visited_id"
+    t.index ["visitor_id", "visited_id"], name: "index_notifications_on_visitor_id_and_visited_id"
+    t.index ["visitor_id"], name: "index_notifications_on_visitor_id"
+  end
+
   create_table "oshi_details", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "reason_for_favorite"
     t.text "trigger_for_favorite"
@@ -175,6 +191,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_02_103324) do
   add_foreign_key "comments", "users"
   add_foreign_key "favorites", "articles"
   add_foreign_key "favorites", "users"
+  add_foreign_key "notifications", "articles"
+  add_foreign_key "notifications", "comments"
+  add_foreign_key "notifications", "users", column: "visited_id"
+  add_foreign_key "notifications", "users", column: "visitor_id"
   add_foreign_key "oshi_details", "oshi_names"
   add_foreign_key "oshi_details", "profiles"
   add_foreign_key "profiles", "users"


### PR DESCRIPTION
## 実装内容
- 自身が作成した記事に他のユーザーがコメントした際に通知が来るように設定

## 上手くいかなかったこと
- 通知が来ている時のアイコンが、一目で通知が来ていることが分かるアイコンにすること

## 修正が必要な部分
- 「コメント通知」をヘッダーにも表示
- コメント通知のアイテムを削除できるようにする
- 一目で通知が来ていることが分かるアイコンに設定

## 今回参考にした記事
https://qiita.com/tktk0430/items/bdb8fbcf4ce3258b2d41

## 今回の実装で気になったこと、今後活かせそうなこと
- ポリモーフィック関連付けでのコメント通知機能
https://zenn.dev/goldsaya/articles/0f387f3e62ff92
