### PR TITLE
i18nとenum_helpの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,7 @@ gem 'config'
 gem 'kaminari'
 
 gem 'ransack'
+
+gem 'rails-i18n', '~> 7.0.0'
+
+gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
       dotenv (= 3.1.2)
       railties (>= 6.1)
     drb (2.2.1)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.13.0)
     excon (0.111.0)
     faraday (2.10.1)
@@ -323,6 +325,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.4)
       actionpack (= 7.1.3.4)
       activesupport (= 7.1.3.4)
@@ -416,6 +421,7 @@ DEPENDENCIES
   debug
   derailed_benchmarks
   dotenv-rails
+  enum_help
   fog-aws
   image_processing (~> 1.2)
   jbuilder
@@ -426,6 +432,7 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
+  rails-i18n (~> 7.0.0)
   ransack
   selenium-webdriver
   sorcery

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -9,9 +9,9 @@
         <% if article.notice.present? %>
           <h3 class="text-pink-500">注意書き：<%= article.notice %></h3>
         <% end %>
-        <h3>カテゴリ：<%= article.category %></h3>
+        <h3>カテゴリ：<%= article.category_i18n %></h3>
         <h3>作成者：<%= link_to article.user.name, profile_path(article.user.profile) %></h3>
-        <h3>作成日：<%= l article.created_at, format: :short %></h3>
+        <h3>作成日：<%= l article.created_at, format: :custom %></h3>
         <%= render 'articles/tag', { article: article } %>
         <% if current_user&.own1?(article) %>
           <div class='ms-auto'>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -4,38 +4,56 @@
       <h1 class="text-2xl font-bold mb-10">記事編集</h1>
       <%= form_with model: @article, local: true do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
+
         <div class="mb-10">
-          <%= f.label :oshi_name_name, "推し名", class: "block mb-1" %>
+          <div class="flex items-center mb-1">
+            <%= f.label :oshi_name_name, class: "block mr-1" %>
+            <p class="text-red-500">(必須)</p>
+          </div>
           <%= f.text_field :oshi_name_name, value: @article.oshi_name&.name, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :title, "タイトル", class: "block mb-1" %>
+          <div class="flex items-center mb-1">
+            <%= f.label :title, class: "block mr-1" %>
+            <p class="text-red-500">(必須)</p>
+          </div>
           <%= f.text_field :title, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :notice, "注意書き", class: "block mb-1" %>
+          <%= f.label :notice, class: "block mb-1" %>
           <%= f.text_field :notice, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :category, "カテゴリ", class: "block mb-1" %>
-          <%= f.select :category, Article.categories.keys.map { |w| [w.humanize, w] }, {}, class: "input input-bordered w-full max-w-xs" %>
+          <%= f.label :category, class: "block mb-1" %>
+          <%= f.select :category, Article.categories_i18n.keys.map { |w| [I18n.t("enums.article.category.#{w}"), w] }, {}, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :content, "本文", class: "block mb-1" %>
+          <div class="flex items-center mb-1">
+            <%= f.label :content, class: "block mr-1" %>
+            <p class="text-red-500">(必須)</p>
+          </div>
           <%= f.rich_text_area :content %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :tag_name, "タグ", class: "block mb-1" %>
+          <%= f.label :tag_name, class: "block mb-1" %>
           <%= f.text_field :tag_name, placeholder: "、で区切って入力してください", value: params[:article] ? params[:article][:tag_name] : @article.tags.map(&:name).join('、'), class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :visible_gender, "公開先[性別]", class: "block mb-1" %>
-          <%= f.select :visible_gender, Article.visible_genders.keys.map { |w| [w.humanize, w] }, {}, class: "input input-bordered w-full max-w-xs" %>
+          <%= f.label :visible_gender, class: "block mb-1" %>
+          <%= f.select :visible_gender, Article.visible_genders_i18n.keys.map { |w| [I18n.t("enums.article.visible_gender.#{w}"), w] }, {}, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :visible_oshi, "公開先[タイトルと同じ推し]", class: "block mb-1" %>
+          <%= f.label :visible_oshi, class: "block mb-1" %>
           <%= f.check_box :visible_oshi, { checked: @article.visible_oshi }, true, false %>
         </div>
+
           <%= f.submit "更新", class: 'btn btn-neutral mb-10' %>
           <%= link_to "戻る", articles_path, class: 'btn btn-neutral mb-10 ml-5' %>
       <% end %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -4,38 +4,56 @@
       <h1 class="text-2xl font-bold mb-10">記事作成</h1>
       <%= form_with model: @article, local: true do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
+
         <div class="mb-10">
-          <%= f.label :oshi_name_name, "推し名", class: "block mb-1" %>
+          <div class="flex items-center mb-1">
+            <%= f.label :oshi_name_name, class: "block mr-1" %>
+            <p class="text-red-500">(必須)</p>
+          </div>
           <%= f.text_field :oshi_name_name, value: @article.oshi_name&.name, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :title, "タイトル", class: "block mb-1" %>
+          <div class="flex items-center mb-1">
+            <%= f.label :title, class: "block mr-1" %>
+            <p class="text-red-500">(必須)</p>
+          </div>
           <%= f.text_field :title, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :notice, "注意書き", class: "block mb-1" %>
+          <%= f.label :notice, class: "block mb-1" %>
           <%= f.text_field :notice, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :category, "カテゴリ", class: "block mb-1" %>
-          <%= f.select :category, Article.categories.keys.map { |w| [w.humanize, w] }, {}, class: "input input-bordered w-full max-w-xs" %>
+          <%= f.label :category, class: "block mb-1" %>
+          <%= f.select :category, Article.categories_i18n.keys.map { |w| [I18n.t("enums.article.category.#{w}"), w] }, {}, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :content, "本文", class: "block mb-1" %>
+          <div class="flex items-center mb-1">
+            <%= f.label :content, class: "block mr-1" %>
+            <p class="text-red-500">(必須)</p>
+          </div>
           <%= f.rich_text_area :content %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :tag_name, "タグ", class: "block mb-1" %>
+          <%= f.label :tag_name, class: "block mb-1" %>
           <%= f.text_field :tag_name, placeholder: "、で区切って入力してください", value: params[:article] ? params[:article][:tag_name] : @article.tags.map(&:name).join('、'), class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :visible_gender, "公開先[性別]", class: "block mb-1" %>
-          <%= f.select :visible_gender, Article.visible_genders.keys.map { |w| [w.humanize, w] }, {}, class: "input input-bordered w-full max-w-xs" %>
+          <%= f.label :visible_gender, class: "block mb-1" %>
+          <%= f.select :visible_gender, Article.visible_genders_i18n.keys.map { |w| [I18n.t("enums.article.visible_gender.#{w}"), w] }, {}, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :visible_oshi, "公開先[タイトルと同じ推し]", class: "block mb-1" %>
+          <%= f.label :visible_oshi, class: "block mb-1" %>
           <%= f.check_box :visible_oshi, { checked: @article.visible_oshi }, true, false %>
         </div>
+
           <%= f.submit "作成", class: 'btn btn-neutral mb-10' %>
           <%= link_to "戻る", articles_path, class: 'btn btn-neutral mb-10 ml-5' %>
       <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -11,8 +11,8 @@
               <h1 class="text-3xl mb-2"><%= @article.title %></h1>
               <h1 class="text-pink-500 mb-2">※注意書き：<%= @article.notice %></h1>
               <h1 class="mb-2">作成者：<%= link_to @article.user.name, profile_path(@article.user.profile) %></h1>
-              <h1 class="mb-2">カテゴリ：<%= @article.category %></h1>
-              <h1 class="mb-2">作成日：<%= l @article.created_at, format: :short %></h1>
+              <h1 class="mb-2">カテゴリ：<%= @article.category_i18n %></h1>
+              <h1 class="mb-2">作成日：<%= l @article.created_at, format: :custom %></h1>
               <h1 class="bg-white p-2 mb-2"><%= @article.content %></h1>
               <%= render 'articles/tag', { article: @article } %>
             </div>

--- a/app/views/oshi_details/new.html.erb
+++ b/app/views/oshi_details/new.html.erb
@@ -3,12 +3,18 @@
     <div class="w-full max-w-5xl">
       <h1 class="text-2xl font-bold mb-10">推し登録</h1>
       <%= form_with model: @oshi_detail, url: profile_oshi_details_path(current_user.profile) do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
+
         <div class="mb-10">
-          <%= f.label :oshi_name_name, "推し名", class: "block mb-1" %>
+          <div class="flex items-center mb-1">
+            <%= f.label :oshi_name_name, class: "block mr-1" %>
+            <p class="text-red-500">(必須)</p>
+          </div>
           <%= f.text_field :oshi_name_name, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-3">
-          <%= f.label :oshi_image, "推し画像", class: "block mb-1" %>
+          <%= f.label :oshi_image, class: "block mb-1" %>
           <%= f.file_field :oshi_image, class: "input input-bordered w-full max-w-xs", accept: 'image/*' %>
           <%= f.hidden_field :profile_image_cache %>
           <div class='mt-3 mb-8'>
@@ -18,18 +24,22 @@
                           size: '100x100' %>
           </div>
         </div>
+
         <div class="mb-10">
-          <%= f.label :reason_for_favorite, "好きな理由", class: "block mb-1" %>
+          <%= f.label :reason_for_favorite, class: "block mb-1" %>
           <%= f.text_area :reason_for_favorite, class: "textarea textarea-bordered w-full max-w-3xl" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :trigger_for_favorite, "好きになったキッカケ", class: "block mb-1" %>
+          <%= f.label :trigger_for_favorite, class: "block mb-1" %>
           <%= f.text_area :trigger_for_favorite, class: "textarea textarea-bordered w-full max-w-3xl" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :activity_history, "推し活履歴", class: "block mb-1" %>
+          <%= f.label :activity_history, class: "block mb-1" %>
           <%= f.text_area :activity_history, class: "textarea textarea-bordered w-full max-w-3xl" %>
         </div>
+
           <%= f.submit "登録", class: 'btn btn-neutral mb-10' %>
           <%= link_to "戻る", profile_path(current_user.profile), class: 'btn btn-neutral mb-10 ml-5' %>
       <% end %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,22 +1,24 @@
-<div class="container mx-auto px-4">
+<div class="container mx-auto px-8">
   <div class="flex justify-center mt-14">
-    <div class="w-full max-w-lg">
-      <h1 class="text-2xl font-bold mb-10">パスワードリセット</h1>
+    <div class="w-full max-w-md">
+      <h1 class="text-2xl font-bold mb-8">パスワードリセット</h1>
       <%= form_with model: @user, url: password_reset_path(@token), method: :patch do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
-        <div class="mb-10">
-          <%= f.label :email, class: "block mb-3" %>
-          <%= f.email_field :email, class: "input input-bordered w-full max-w-xs" %>
+        <div class="mb-6">
+          <%= f.label :email, class: "block mb-2" %>
+          <%= f.email_field :email, class: "input input-bordered w-full" %>
         </div>
-        <div class="mb-10">
-          <%= f.label :password, class: "block mb-3" %>
-          <%= f.password_field :password, class: "input input-bordered w-full max-w-xs" %>
+        <div class="mb-6">
+          <%= f.label :password, class: "block mb-2" %>
+          <%= f.password_field :password, class: "input input-bordered w-full" %>
         </div>
-        <div class="mb-10">
-          <%= f.label :password_confirmation, class: "block mb-3" %>
-          <%= f.password_field :password_confirmation, class: "input input-bordered w-full max-w-xs" %>
+        <div class="mb-6">
+          <%= f.label :password_confirmation, class: "block mb-2" %>
+          <%= f.password_field :password_confirmation, class: "input input-bordered w-full" %>
         </div>
-        <%= f.submit "パスワード再設定", class: 'btn btn-neutral mb-5' %>
+        <div class="mx-auto flex justify-center text-center">
+          <%= f.submit "パスワード再設定", class: 'btn btn-neutral' %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,13 +1,15 @@
-<div class="container mx-auto px-4">
+<div class="container mx-auto px-8">
   <div class="flex justify-center mt-14">
-    <div class="w-full max-w-lg">
-      <h1 class="text-2xl font-bold mb-10">パスワードリセット申請</h1>
+    <div class="w-full max-w-md">
+      <h1 class="text-2xl font-bold mb-8">パスワードリセット申請</h1>
       <%= form_with url: password_resets_path do |f| %>
-        <div class="mb-10">
-          <%= f.label :email, class: "block mb-3" %>
-          <%= f.email_field :email, class: "input input-bordered w-full max-w-xs" %>
+        <div class="mb-6">
+          <%= f.label :email, class: "block mb-2" %>
+          <%= f.email_field :email, class: "input input-bordered w-full" %>
         </div>
-        <%= f.submit "メールを送信する", class: 'btn btn-neutral mb-5' %>
+        <div class="mx-auto flex justify-center text-center mb-4">
+          <%= f.submit "メールを送信する", class: 'btn btn-neutral mb-5' %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -4,12 +4,14 @@
       <h1 class="text-2xl font-bold mb-10">プロフィール編集</h1>
       <%= form_with model: @profile do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
+
         <div class="mb-10">
-          <%= f.label :name, "ニックネーム", class: "block mb-1" %>
+          <%= f.label :name, class: "block mb-1" %>
           <%= f.text_field :name, value: @profile.user.name, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-3">
-          <%= f.label :profile_image, "プロフィール画像", class: "block mb-1" %>
+          <%= f.label :profile_image, class: "block mb-1" %>
           <%= f.file_field :profile_image, class: "input input-bordered w-full max-w-xs", accept: 'image/*' %>
           <%= f.hidden_field :profile_image_cache %>
           <div class='mt-3 mb-8'>
@@ -19,18 +21,22 @@
                           size: '100x100' %>
           </div>
         </div>
+
         <div class="mb-10">
-          <%= f.label :gender, "性別", class: "block mb-1" %>
-          <%= f.select :gender, Profile.genders.keys.map { |w| [w.humanize, w] }, {}, class: "input input-bordered w-full max-w-xs" %>
+          <%= f.label :gender, class: "block mb-1" %>
+          <%= f.select :gender, Profile.genders_i18n.keys.map { |w| [I18n.t("enums.profile.gender.#{w}"), w] }, {}, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :birth_year, "誕生年度", class: "block mb-1" %>
+          <%= f.label :birth_year, class: "block mb-1" %>
           <%= f.select :birth_year, options_for_select((1900..Time.now.year).to_a.reverse, selected: @profile.birth_year || '選択なし'), { include_blank: '選択なし' }, class: "input input-bordered w-full max-w-xs" %>
         </div>
+
         <div class="mb-10">
-          <%= f.label :self_introduction, "自己紹介", class: "block mb-1" %>
+          <%= f.label :self_introduction, class: "block mb-1" %>
           <%= f.text_area :self_introduction, class: "textarea textarea-bordered w-full max-w-3xl" %>
         </div>
+
           <%= f.submit "登録", class: 'btn btn-neutral mb-10' %>
           <%= link_to "戻る", profile_path, class: 'btn btn-neutral mb-10 ml-5' %>
       <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -10,7 +10,7 @@
           <div class="w-full max-w-3xl">
             <div class="flex">
               <p>性別：</p>
-              <p><%= @profile.gender %></p>
+              <p><%= @profile.gender_i18n %></p>
             </div>
             <div class="flex">
               <p>誕生年度：</p>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -5,19 +5,19 @@
       <%= form_with model: @user do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
         <div class="mb-4">
-          <%= f.label :name, class: "block mb-3" %>
+          <%= f.label :name, class: "block mb-2" %>
           <%= f.text_field :name, class: "input input-bordered w-full" %>
         </div>
         <div class="mb-4">
-          <%= f.label :email, class: "block mb-3" %>
+          <%= f.label :email, class: "block mb-2" %>
           <%= f.email_field :email, class: "input input-bordered w-full" %>
         </div>
         <div class="mb-4">
-          <%= f.label :password, class: "block mb-3" %>
+          <%= f.label :password, class: "block mb-2" %>
           <%= f.password_field :password, class: "input input-bordered w-full" %>
         </div>
         <div class="mb-4">
-          <%= f.label :password_confirmation, class: "block mb-3" %>
+          <%= f.label :password_confirmation, class: "block mb-2" %>
           <%= f.password_field :password_confirmation, class: "input input-bordered w-full" %>
         </div>
         <div class="mx-auto flex justify-center text-center mb-4">

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,10 @@ module Myapp
       g.skip_routes true         # ルーティングの記述を作成しない
     end
 
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
+
     config.active_storage.variant_processor = :mini_magick
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,52 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+      article: 記事
+      profile: プロフィール
+    attributes:
+      user:
+        email: メールアドレス
+        name: ニックネーム
+        password: パスワード
+        password_confirmation: パスワード確認
+      article:
+        oshi_name_name: 推し名
+        title: タイトル
+        notice: 注意書き
+        category: カテゴリ
+        content: 本文
+        tag_name: タグ
+        visible_gender: 公開先[性別]
+        visible_oshi: 公開先[記事と同じ推し]
+        # エラーメッセージの推し名の日本語化が下記の設定でできる
+        oshi_name: 推し名
+      profile:
+        name: ニックネーム
+        profile_image: プロフィール画像
+        gender: 性別
+        birth_year: 誕生年度
+        self_introduction: 自己紹介
+      oshi_detail:
+        oshi_name_name: 推し名
+        oshi_image: 推し画像
+        reason_for_favorite: 好きな理由
+        trigger_for_favorite: 好きになったキッカケ
+        activity_history: 推し活履歴
+        # エラーメッセージの推し名の日本語化が下記の設定でできる
+        oshi_name: 推し名
+  enums:
+    article:
+      category:
+        others: その他
+        impression: 感想記事
+        introduction: 紹介記事
+      visible_gender:
+        not_selected: 選択なし
+        male: 男性
+        female: 女性
+    profile:
+      gender:
+        not_selected: 選択なし
+        male: 男性
+        female: 女性

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,8 @@
+ja:
+  helpers:
+    label:
+      email: メールアドレス
+      password: パスワード
+  time:
+    formats:
+      custom: "%Y年%m月%d日"


### PR DESCRIPTION
## 実装した内容
- i18nの導入（users、user_sessions、articles、profiles、oshi_detailsのモデルの最低限だけ設定）
- enum_help導入、enumの情報の日本語化
- 作成日を〇〇〇〇年〇月〇日に設定
- パスワードリセットページのデザイン修正

## 参考文献
- enumの日本語化
https://qiita.com/sazumy/items/d44a92425188a4489ec6