### PR TITLE
記事の非公開機能

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -12,6 +12,7 @@ class Article < ApplicationRecord
 
   enum category: { others: 0, impression: 1, introduction: 2 }
   enum visible_gender: { not_selected: 0, male: 1, female: 2 }
+  enum status: { published: 0, unpublished: 1 }
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :notice, length: { maximum: 100 }
@@ -19,6 +20,7 @@ class Article < ApplicationRecord
   validates :visible_gender, presence: true
   validates :visible_oshi, inclusion: { in: [true, false] }
   validates :content, presence: true
+  validates :status, presence: true
 
   def self.ransackable_attributes(auth_object = nil)
     %w[title category]

--- a/app/views/articles/_article.html.erb
+++ b/app/views/articles/_article.html.erb
@@ -3,7 +3,11 @@
     <div class="card bg-base-100 max-w-3xl min-h-20 shadow-xl">
       <div class="py-3 px-2">
 
-        <div class="mx-auto flex items-center justify-center">
+        <% if article.unpublished? %>
+          <h1 class="text-sm text-pink-500">非公開</h1>
+        <% end %>
+
+        <div class="mx-auto flex items-center justify-between">
           <h1 class="text-sm"><%= article.oshi_name.name %></h1>
           <% if current_user&.own1?(article) %>
             <div class='ms-auto mr-2'>
@@ -12,7 +16,7 @@
               <% end %>
             </div>
           <% elsif logged_in? %>
-            <div class='ms-auto mr-2'>
+            <div class='mr-2'>
               <%= render 'shared/favorite_buttons', { article: article } %>
             </div>
           <% end %>
@@ -43,6 +47,9 @@
           <%= render 'articles/tag', { article: article } %>
         </div>
 
+        
+          
+        
       </div>
     </div>
   </div>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -60,7 +60,8 @@
         </div>
         
         <div class="mx-auto flex justify-center text-center mb-10">
-          <%= f.submit "更新", class: 'btn btn-neutral mr-20' %>
+          <%= f.submit "公開", id: 'publishButton', name: 'published', class: 'btn btn-neutral mr-10' %>
+          <%= f.submit "非公開で保存", id: 'unpublishButton', name: 'unpublished', class: "btn btn-neutral mr-10" %>
           <%= link_to "戻る", articles_path, data: { turbo_method: :get, turbo_confirm: "記事は更新されていませんが、よろしいでしょうか？" }, class: 'btn btn-neutral' %>
         </div>
 

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -60,7 +60,8 @@
         </div>
 
         <div class="mx-auto flex justify-center text-center mb-10">
-          <%= f.submit "作成", class: 'btn btn-neutral mr-20' %>
+          <%= f.submit "公開", id: 'publishButton', name: 'published', class: 'btn btn-neutral mr-10' %>
+          <%= f.submit "非公開で保存", id: 'unpublishButton', name: 'unpublished', class: "btn btn-neutral mr-10" %>
           <%= link_to "戻る", articles_path, data: { turbo_method: :get, turbo_confirm: "記事は保存されていませんが、よろしいでしょうか？" }, class: 'btn btn-neutral' %>
         </div>
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -5,6 +5,10 @@
         <div class="flex justify-center m-2">
           <div class="w-full max-w-3xl">
 
+            <% if @article.unpublished? %>
+              <h1 class="text-base text-pink-500">非公開</h1>
+            <% end %>
+
             <div class="mx-auto flex items-center">
               <h1 class="text-base mb-1"><%= @article.oshi_name.name %></h1>
               <% if current_user&.own1?(@article) %>

--- a/db/migrate/20241127075402_add_status_to_articles.rb
+++ b/db/migrate/20241127075402_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :articles, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_18_080733) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_27_075402) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -69,6 +69,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_18_080733) do
     t.bigint "oshi_name_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0, null: false
     t.index ["oshi_name_id"], name: "index_articles_on_oshi_name_id"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end


### PR DESCRIPTION
## 実装した内容
- 記事の非公開機能を実装（元は下書きと非公開に分けていたが、ほとんど同じようになりそうだったため非公開に統一）
- 非公開記事は記事一覧ページに表示されない、自分の記事一覧には表示されるように設定

## 導入したい内容
- 記事詳細ページで「公開」「非公開」を変更できる

## 参考文献
https://zenn.dev/ganmo3/articles/30ca50ce4868b2