### PR TITLE
Character counter comment

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,6 +9,7 @@ import "./trix-editor-overrides"
 import "./pages/articles"
 import "./pages/profiles"
 import "./pages/oshi_details"
+import "./pages/comments"
 
 import Rails from '@rails/ujs';
 Rails.start();

--- a/app/javascript/pages/articles.js
+++ b/app/javascript/pages/articles.js
@@ -1,4 +1,4 @@
-document.addEventListener("turbo:load", function () {
+function setupCharacterCountArticle() {
   // タイトルの文字数カウント
   const inputTextTitle = document.getElementById('inputTextTitle');
   const characterCountTitle = document.getElementById('characterCountTitle');
@@ -48,4 +48,9 @@ document.addEventListener("turbo:load", function () {
     // **キー入力時にカウントを更新**
     inputTextNotice.addEventListener('keyup', keyUpNotice);
   }
-});
+};
+
+// **ページロード時・Turbo遷移後にセットアップ**
+document.addEventListener("turbo:load", setupCharacterCountArticle);
+document.addEventListener("turbo:frame-load", setupCharacterCountArticle);
+document.addEventListener("turbo:render", setupCharacterCountArticle);

--- a/app/javascript/pages/comments.js
+++ b/app/javascript/pages/comments.js
@@ -1,0 +1,27 @@
+document.addEventListener("turbo:load", function () {
+  // タイトルの文字数カウント
+  const inputTextComment = document.getElementById('inputTextComment');
+  const characterCountComment = document.getElementById('characterCountComment');
+  const characterCountWrapComment = document.getElementById('characterCountWrapComment');
+  
+
+  if (inputTextComment) {
+    function keyUpComment() {
+      let str = inputTextComment.value.replace(/\r?\n/g, '');
+      let num = 1000 - str.length;
+
+      characterCountComment.textContent = num;
+      if(num >= 0) {
+        characterCountWrapComment.style.color = 'black';
+      } else {
+        characterCountWrapComment.style.color = 'red';
+      }
+    }
+
+    // **ページロード時にカウントを更新**
+    keyUpComment();
+
+    // **キー入力時にカウントを更新**
+    inputTextComment.addEventListener('keyup', keyUpComment);
+  }
+});

--- a/app/javascript/pages/comments.js
+++ b/app/javascript/pages/comments.js
@@ -8,7 +8,7 @@ document.addEventListener("turbo:load", function () {
   if (inputTextComment) {
     function keyUpComment() {
       let str = inputTextComment.value.replace(/\r?\n/g, '');
-      let num = 1000 - str.length;
+      let num = 200 - str.length;
 
       characterCountComment.textContent = num;
       if(num >= 0) {

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ApplicationRecord
-  validates :body, presence: true, length: { maximum: 500 }
+  validates :body, presence: true, length: { maximum: 200 }
 
   belongs_to :user
   belongs_to :article

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,9 +1,13 @@
 <div id="comment-form">
   <%= form_with model: comment, url: article_comments_path(article) do |f| %>
-    <%= f.label :body, "コメント", class: "block text-sm mb-1" %>
+    <div class="flex items-center mb-1">
+      <%= f.label :body, "コメント", class: "text-sm" %>
+      <p class="ml-2">※最大200文字</p>
+    </div>
     <div class="flex items-center space-x-4">
       <div class="flex-1">
-        <%= f.text_area :body, class: "textarea textarea-bordered w-full min-h-24" %>
+        <%= f.text_area :body, id: "inputTextComment", class: "textarea textarea-bordered w-full min-h-24" %>
+        <p id="characterCountWrapComment" class="flex justify-end">残り<span id="characterCountComment">200</span>文字</p>
       </div>
       <div class="flex-none">
         <%= f.submit "作成", class: 'btn btn-neutral lg:btn-md btn-sm' %>

--- a/app/views/oshi_details/_form.html.erb
+++ b/app/views/oshi_details/_form.html.erb
@@ -5,7 +5,7 @@
     <%= f.label :oshi_name_name, class: "block mr-1" %>
     <p class="text-red-500">(必須)</p>
   </div>
-  <%= f.text_field :oshi_name_name, class: "input input-bordered w-full" %>
+  <%= f.text_field :oshi_name_name, value: @oshi_detail.oshi_name&.name, class: "input input-bordered w-full" %>
 </div>
 
 <div class="mb-4">


### PR DESCRIPTION
## 概要
記事のコメントのフォームに「残り〇〇文字」の文字数カウンターを設定

## 実装内容
- [x] コメントの本文のバリデーションを200文字に変更

- [x] コメントフォームに「※最大200文字まで」と表記

- [x] コメントフォームに文字数カウンターを設定

- [x] 文字数がバリデーションを超えた時に「残り-〇〇文字」になるように設定

- [x] マイナスになった時に赤文字になるように設定

- [ ] 編集フォームに移動した時に既に保存されている文字数が初めからカウントされている。

## 追加修正
- 記事作成、記事編集ページでバリデーションエラーが発生した場合に、文字数カウンターが正常に動かない問題を修正(通常リロードやrenderでの再表示でも動くように設定)
- 推し登録編集画面で、既に保存されている推し名が表示されない問題を修正

## 備考
今までと違い_edit_form.html.erbがあるため、今までのやり方ではうまくいかない可能性があり

## 上手くいかなかった点
- 作成フォームを空で作成ボタンを押した後に、フォームに入力すると文字数カウンターが正常に動かなかった。
- 編集フォームでは文字カウンターが正常に動かなかった。