### PR TITLE
デザインの微調整（特にトップページ）

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-3xl">
-      <div class="bg-base-200 min-h-3.5 p-3">
+      <div class="bg-base-200 min-h-3.5 rounded-xl p-3">
 
         <% if @article.unpublished? %>
           <h1 class="text-base lg:text-lg text-pink-500">非公開</h1>
@@ -61,7 +61,7 @@
 
 
       <!-- コメント入力フォーム -->
-      <div class="bg-base-200 min-h-3.5 mt-2 p-4">
+      <div class="bg-base-200 min-h-3.5 rounded-xl mt-2 p-4">
         <%= render 'comments/form', comment: @comment, article: @article %>
       </div>
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,5 +1,5 @@
 <div id="comment-id-<%= comment.id %>">
-  <div class="min-h-3.5 p-1">
+  <div class="min-h-3.5">
     <div class="container mx-auto">
       <div class="flex justify-center">
         <div class="w-full max-w-3xl">

--- a/app/views/profiles/_follow_user.html.erb
+++ b/app/views/profiles/_follow_user.html.erb
@@ -1,6 +1,6 @@
-<div class="bg-base-200 min-h-3.5 py-1 px-2">
+<div class="min-h-3.5 py-1 px-2">
   <div id="profile-id-<%= follow_user.profile.id %>">
-    <div class="card bg-base-100 max-w-3xl min-h-20 shadow-xl">
+    <div class="card bg-base-200 max-w-3xl min-h-20 shadow-xl">
       <div class="py-3 px-2">
 
         <div class="flex items-center">
@@ -17,18 +17,20 @@
 
         <div class="mt-2 mx-2">
           <div class="flex">
-            <p class="text-base lg:text-lg">性別：</p>
-            <p class="text-base lg:text-lg"><%= follow_user.profile.gender_i18n %></p>
+            <h1 class="text-base lg:text-lg">性別：</h1>
+            <h1 class="text-base lg:text-lg"><%= follow_user.profile.gender_i18n %></h1>
           </div>
           <div class="flex">
-            <p class="text-base lg:text-lg">誕生年度：</p>
-            <p class="text-base lg:text-lg"><%= follow_user.profile.birth_year || '選択なし' %></p>
+            <h1 class="text-base lg:text-lg">誕生年度：</h1>
+            <h1 class="text-base lg:text-lg"><%= follow_user.profile.birth_year || '選択なし' %></h1>
           </div>
           <div>
-            <p class="text-base lg:text-lg">自己紹介：</p>
-            <% if follow_user.profile.self_introduction.present? %>
-              <p class="text-base lg:text-lg"><%= follow_user.profile.self_introduction.truncate(45, omission: '...') %></p>
-            <% end %>
+            <h1 class="text-base lg:text-lg">自己紹介</h1>
+            <div class="bg-base-100 rounded-lg">
+              <% if follow_user.profile.self_introduction.present? %>
+                <h1 class="text-base lg:text-lg p-2"><%= follow_user.profile.self_introduction.truncate(45, omission: '...') %></h1>
+              <% end %>
+            </div>
           </div>
           
         </div>

--- a/app/views/profiles/_user_search_form.html.erb
+++ b/app/views/profiles/_user_search_form.html.erb
@@ -4,7 +4,7 @@
     <div class="mr-1">
       <%= f.label :profile_gender, "性別", class: "text-sm font-medium text-gray-700" %>
     </div>
-    <div class="mr-4">
+    <div class="mr-2 lg:mr-4">
       <%= f.select :profile_gender_eq, Profile.genders.keys.map.with_index { |k, i| [t("enums.profile.gender.#{k}"), i] }, { include_blank: 'すべて' }, class: "input input-bordered" %>
     </div>
     <div class="mr-1">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-3xl">
 
-      <div class="bg-base-200 min-h-3.5 p-2">
+      <div class="bg-base-200 min-h-3.5 rounded-xl p-2">
         <div class="flex items-center my-1 mx-1">
           <div class="avatar mr-2">
             <div class="w-20 rounded-full">
@@ -33,7 +33,9 @@
           <div>
             <h1 class="text-base lg:text-lg">自己紹介</h1>
             <div class="bg-base-100 rounded-lg">
-              <h1 class="text-sm lg:text-base p-2"><%= simple_format(@profile.self_introduction) %></h1>
+              <% if @profile.self_introduction.present? %>
+                <h1 class="text-sm lg:text-base p-2"><%= simple_format(@profile.self_introduction) %></h1>
+              <% end %>
             </div>
           </div>
 
@@ -45,7 +47,7 @@
 
   <div class="flex justify-center mt-2">
     <div class="w-full max-w-3xl">
-      <div class="bg-base-200 min-h-3.5 p-2">
+      <div class="bg-base-200 min-h-3.5 rounded-xl p-2">
         <h1 class="text-lg lg:text-xl font-bold"><%= link_to "#{@profile.user.name}記事一覧", my_articles_profile_path(@profile), class: "text-blue-500 hover:underline" %></h1>
       </div>
     </div>
@@ -53,7 +55,7 @@
 
   <div class="flex justify-center mt-2">
     <div class="w-full max-w-3xl">
-      <div class="bg-base-200 min-h-3.5 p-2">
+      <div class="bg-base-200 min-h-3.5 rounded-xl p-2">
         <% if current_user == @profile.user %>
           <%= link_to new_profile_oshi_detail_path(@profile) do %>
             <i class="fa-solid fa-plus text-base lg:text-lg">推し追加</i>
@@ -61,7 +63,11 @@
         <% end %>
         <div>
           <!-- 推し一覧 -->
-          <%= render partial: 'oshi_detail', collection: @oshi_details %>
+          <% if @oshi_details.present? %>
+            <%= render partial: 'oshi_detail', collection: @oshi_details %>
+          <% else %>
+            <h1 class="text-center text-lg">推しは登録されていません</h1>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -50,10 +50,7 @@
         <p class="text-lg mb-2">ログインしてプロフィール作成や記事を</br>
                             作成してみよう！</p>
         <%= link_to "ログイン", login_path, class: 'btn btn-neutral' %>
-        
-
       </div>
-      
       
     </div>
   </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4">
   <div class="flex justify-center mt-10">
     <div class="w-full max-w-3xl">
-      <div class="bg-base-200 min-h-20 p-2 mb-8">
+      <div class="bg-base-200 min-h-20 rounded-full p-2 mb-8">
         <div class="text-sm lg:text-xl text-center my-2">
           <h1 class="text-2xl lg:text-3xl font-bold mb-2">推しOPEN</h1>
           <p class>推しについて発信したい！推し仲間を探したい！</br>
@@ -21,14 +21,14 @@
       <h2 class="text-center text-lg font-bold mb-2">まずは自分のプロフィールを公開しよう！</h2>
 
       <div class="text-center mb-14 lg:grid grid-cols-2 gap-2">
-        <div class="bg-base-200 min-h-24 mb-6 lg:mb-0">
+        <div class="bg-base-200 min-h-24 rounded-xl mb-6 lg:mb-0">
           <h1 class="font-bold text-lg pt-2 lg:pt-4">プロフィールの登録</h1>
           <div class="flex justify-center">
             <img src="https://i.gyazo.com/86594fa70797c2cdf9b4e77a80605a40.png" alt="Image from Gyazo" width="490" class="p-2"/>
           </div>
           <p class="py-2 lg:pt-6">性別や誕生年度、自己紹介を登録</p>
         </div>
-        <div class="bg-base-200 min-h-24">
+        <div class="bg-base-200 min-h-24 rounded-xl">
           <h1 class="font-bold text-lg pt-2 lg:pt-4">推しの登録</h1>
           <div class="flex justify-center">
             <img src="https://i.gyazo.com/c34e1b78914c03ed470e0f9bc75fa260.gif" alt="Image from Gyazo" width="490" class="p-2"/>
@@ -37,10 +37,10 @@
         </div>
       </div>
       <h2 class="text-center text-lg font-bold mb-2">記事を作成して推しについて発信しよう！</h2>
-      <div class="max-w-xl mx-auto text-center bg-base-200 min-h-20 mb-8">
+      <div class="max-w-xl mx-auto text-center bg-base-200 min-h-20 rounded-xl mb-8">
         <h1 class="font-bold text-lg pt-2">記事の作成</h1>
         <div class="flex justify-center">
-          <img src="https://i.gyazo.com/93bdb2a0dc2222ae0395c9737e8ef7b5.gif" alt="Image from Gyazo" width="490" class="p-2 max-w-[350px]"/>
+          <img src="https://i.gyazo.com/93bdb2a0dc2222ae0395c9737e8ef7b5.gif" alt="Image from Gyazo" width="490" class="p-3 max-w-[350px]"/>
         </div>
         <p class="py-2">同性や同じ推しを推しているユーザーだけに</br>
           公開することも可能！</p>


### PR DESCRIPTION
## 概要
デザインの見直し

## 実装内容
- トップページのデザイン修正
  - [x] 青背景に丸みを持たせる
  - [x] パディングの微調整

- [x] プロフィールページの青背景に丸みを持たせる

- [x] お気に入りユーザー一覧のカードを青色に変更

- [x] お気に入りユーザー一覧の検索欄の微調整

## 関連issue
#208 