### PR TITLE
アイコンの設定

### DIFF
--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,39 +1,39 @@
-<div id="notification-id-<%= notification.id %>">
-<div class="bg-base-200 min-h-3.5 p-1">
-  <div class="card bg-base-100 max-w-3xl min-h-20 shadow-xl">
-    <div class="py-3 px-2">
+<div class="min-h-3.5 py-1 px-2">
+  <div id="notification-id-<%= notification.id %>">
+    <div class="card bg-base-200 max-w-3xl min-h-20 shadow-xl">
+      <div class="py-3 px-2">
 
-      <%= link_to mark_as_read_notification_path(notification), method: :patch, class: "flex flex-row flex-auto 3xl items-center hover:bg-gray-300" do %>
-        <div class="flex items-center">
-          <div class="avatar mr-2">
-            <div class="w-10 rounded-full">
-              <%= image_tag notification.visitor.profile.profile_image.url %>
+        <%= link_to mark_as_read_notification_path(notification), method: :patch, class: "flex flex-row flex-auto 3xl items-center hover:bg-gray-300" do %>
+          <div class="flex items-center">
+            <div class="avatar mr-2">
+              <div class="w-10 rounded-full">
+                <%= image_tag notification.visitor.profile.profile_image.url %>
+              </div>
             </div>
-          </div>
-          <div class="flex flex-col">
-            <% case notification.action %>
-            <% when 'comment' %>
-              <% if notification.article.user_id == notification.visited.id %>
-                <h1 class="text-sm"><%= notification.visitor.name %>さんがあなたの投稿にコメントしました</h1>
+            <div class="flex flex-col">
+              <% case notification.action %>
+              <% when 'comment' %>
+                <% if notification.article.user_id == notification.visited.id %>
+                  <h1 class="text-sm"><%= notification.visitor.name %>さんがあなたの投稿にコメントしました</h1>
+                <% end %>
               <% end %>
+              <h1 class="text-slate-400 text-sm">コメント投稿日：<%= l notification.created_at, format: :custom %></h1>
+            </div>
+          <% end %>
+
+          <div class="items-center ml-auto">
+            <%= link_to notification_path(notification), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
+              <i class="fa-solid fa-trash"></i>
             <% end %>
-            <h1 class="text-slate-400 text-sm">コメント投稿日：<%= l notification.created_at, format: :custom %></h1>
+            <%# 未読の場合は丸を表示 %>
+            <% if notification.checked == false %>
+              <i class="fa-solid fa-circle text-orange-500"></i>
+            <% end %>
           </div>
-        <% end %>
-
-        <div class="items-center ml-auto">
-          <%= link_to notification_path(notification), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } do %>
-            <i class="fa-solid fa-trash"></i>
-          <% end %>
-          <%# 未読の場合は丸を表示 %>
-          <% if notification.checked == false %>
-            <i class="fa-solid fa-circle text-orange-500"></i>
-          <% end %>
         </div>
-      </div>
 
+      </div>
     </div>
   </div>
-</div>
 </div>
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -3,8 +3,9 @@
     <div class="w-full max-w-3xl">
       <h1 class="text-center text-2xl font-bold mb-4">コメント通知</h1>
     
-      
         <% notifications = @notifications.where.not(visitor_id: current_user.id) %>
+
+        <!-- 通知一覧 -->
         <% if @notifications.present? %>
           <%= render partial: 'notification', collection: notifications %>
         <% else %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -24,9 +24,24 @@
         <label for="my-drawer-4" aria-label="close sidebar" class="drawer-overlay"></label>
         <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4">
           <!-- サイドバーの内容 -->
-          <li><%= link_to "記事一覧", articles_path %></li>
-          <li><%= link_to "ログイン", login_path %></li>
-          <li><%= link_to "新規作成", new_user_path %></li>
+          <li>
+            <%= link_to articles_path do %>
+              <i class="fa-solid fa-list"></i>
+              <span>記事一覧</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to login_path do %>
+              <i class="fa-solid fa-right-to-bracket"></i>
+              <span>ログイン</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to new_user_path do %>
+              <i class="fa-solid fa-user-plus"></i>
+              <span>新規作成</span>
+            <% end %>
+          </li>
           <div class="divider divider-neutral"></div>
           <li><%= link_to "プライバシーリテラシー", policy_path %></li>
           <li><%= link_to "利用規約", term_path %></li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -51,14 +51,58 @@
         <label for="my-drawer-5" aria-label="close sidebar" class="drawer-overlay"></label>
         <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4">
           <!-- サイドバーの内容 -->
-          <li><%= link_to "記事一覧", articles_path %></li>
-          <li><%= link_to "記事作成", new_article_path %></li>
+          <li>
+            <%= link_to articles_path do %>
+              <i class="fa-solid fa-list"></i>
+              <span>記事一覧</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to new_article_path do %>
+              <i class="fa-solid fa-pen-to-square"></i>
+              <span>記事作成</span>
+            <% end %>
+          </li>
           <div class="divider divider-neutral"></div>
-          <li><%= link_to "マイページ", profile_path(current_user.profile) %></li>
-          <li><%= link_to "自分の記事一覧", my_articles_profile_path(current_user.profile) %></li>
-          <li><%= link_to "お気に入り記事一覧", favorite_articles_profile_path(current_user.profile) %></li>
-          <li><%= link_to "お気に入りユーザー一覧", follow_users_profile_path(current_user.profile) %></li>
-          <li><%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %></li>
+          <li>
+            <%= link_to profile_path(current_user.profile) do %>
+              <i class="fa-solid fa-address-card"></i>
+              <span>マイページ</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to my_articles_profile_path(current_user.profile) do %>
+              <div>
+                <i class="fa-solid fa-circle-user"></i>
+                <i class="fa-solid fa-list"></i>
+              </div>
+              <span>自分の記事一覧</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to favorite_articles_profile_path(current_user.profile) do %>
+              <div>
+                <i class="fa-solid fa-heart"></i>
+                <i class="fa-solid fa-list"></i>
+              </div>
+              <span>お気に入り記事一覧</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to follow_users_profile_path(current_user.profile) do %>
+              <div>
+                <i class="fa-solid fa-heart"></i>
+                <i class="fa-solid fa-users"></i>
+              </div>
+              <span>お気に入りユーザー一覧</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to logout_path, data: { turbo_method: :delete } do %>
+              <i class="fa-solid fa-right-from-bracket"></i>
+              <span>ログアウト</span>
+            <% end %>
+          </li>
           <div class="divider divider-neutral"></div>
           <li><%= link_to "プライバシーリテラシー", policy_path %></li>
           <li><%= link_to "利用規約", term_path %></li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,11 +21,58 @@
         <label for="my-drawer-4" aria-label="close sidebar" class="drawer-overlay"></label>
         <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4">
           <!-- サイドバーの内容 -->
-          <li><%= link_to "マイページ", profile_path(current_user.profile) %></li>
-          <li><%= link_to "自分の記事一覧", my_articles_profile_path(current_user.profile) %></li>
-          <li><%= link_to "お気に入り記事一覧", favorite_articles_profile_path(current_user.profile) %></li>
-          <li><%= link_to "お気に入りユーザー一覧", follow_users_profile_path(current_user.profile) %></li>
-          <li><%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %></li>
+          <li>
+            <%= link_to articles_path do %>
+              <i class="fa-solid fa-list"></i>
+              <span>記事一覧</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to new_article_path do %>
+              <i class="fa-solid fa-pen-to-square"></i>
+              <span>記事作成</span>
+            <% end %>
+          </li>
+          <div class="divider divider-neutral"></div>
+          <li>
+            <%= link_to profile_path(current_user.profile) do %>
+              <i class="fa-solid fa-address-card"></i>
+              <span>マイページ</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to my_articles_profile_path(current_user.profile) do %>
+              <div>
+                <i class="fa-solid fa-circle-user"></i>
+                <i class="fa-solid fa-list"></i>
+              </div>
+              <span>自分の記事一覧</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to favorite_articles_profile_path(current_user.profile) do %>
+              <div>
+                <i class="fa-solid fa-heart"></i>
+                <i class="fa-solid fa-list"></i>
+              </div>
+              <span>お気に入り記事一覧</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to follow_users_profile_path(current_user.profile) do %>
+              <div>
+                <i class="fa-solid fa-heart"></i>
+                <i class="fa-solid fa-users"></i>
+              </div>
+              <span>お気に入りユーザー一覧</span>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to logout_path, data: { turbo_method: :delete } do %>
+              <i class="fa-solid fa-right-from-bracket"></i>
+              <span>ログアウト</span>
+            <% end %>
+          </li>
           <div class="divider divider-neutral"></div>
           <li><%= link_to "プライバシーリテラシー", policy_path %></li>
           <li><%= link_to "利用規約", term_path %></li>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -5,7 +5,7 @@
         <div class="text-sm lg:text-xl text-center my-2">
           <h1 class="text-2xl lg:text-3xl font-bold mb-2">推しOPEN</h1>
           <p class>推しについて発信したい！推し仲間を探したい！</br>
-            でも、人の目に触れることに躊躇している・・・・。</br>
+            でも、人の目に触れることに躊躇している・・。</br>
             そんな人はいませんか？　私はそうでした!</br>
             そんな私の思いから作成された「推しOPEN」</br>
             ここならそんな人でも発信ができます！</p>
@@ -22,14 +22,20 @@
 
       <div class="text-center mb-14 lg:grid grid-cols-2 gap-2">
         <div class="bg-base-200 min-h-24 rounded-xl mb-6 lg:mb-0">
-          <h1 class="font-bold text-lg pt-2 lg:pt-4">プロフィールの登録</h1>
+          <div class="pt-2">
+            <i class="fa-regular fa-address-card"></i>
+            <span class="font-bold text-lg">プロフィールの登録</span>
+          </div>
           <div class="flex justify-center">
             <img src="https://i.gyazo.com/86594fa70797c2cdf9b4e77a80605a40.png" alt="Image from Gyazo" width="490" class="p-2"/>
           </div>
           <p class="py-2 lg:pt-6">性別や誕生年度、自己紹介を登録</p>
         </div>
         <div class="bg-base-200 min-h-24 rounded-xl">
-          <h1 class="font-bold text-lg pt-2 lg:pt-4">推しの登録</h1>
+          <div class="pt-2">
+            <i class="fa-solid fa-heart-circle-plus"></i>
+            <span class="font-bold text-lg">推しの登録</span>
+          </div>
           <div class="flex justify-center">
             <img src="https://i.gyazo.com/c34e1b78914c03ed470e0f9bc75fa260.gif" alt="Image from Gyazo" width="490" class="p-2"/>
           </div>
@@ -38,7 +44,10 @@
       </div>
       <h2 class="text-center text-lg font-bold mb-2">記事を作成して推しについて発信しよう！</h2>
       <div class="max-w-xl mx-auto text-center bg-base-200 min-h-20 rounded-xl mb-8">
-        <h1 class="font-bold text-lg pt-2">記事の作成</h1>
+        <div class="pt-2">
+          <i class="fa-solid fa-pen-to-square"></i>
+          <span class="font-bold text-lg">記事の作成</span>
+        </div>
         <div class="flex justify-center">
           <img src="https://i.gyazo.com/93bdb2a0dc2222ae0395c9737e8ef7b5.gif" alt="Image from Gyazo" width="490" class="p-3 max-w-[350px]"/>
         </div>


### PR DESCRIPTION
## 概要
サイドメニューなどの項目にアイコンを設定する

## 実装内容
- ログイン後のスマホ版のサイドメニューの以下の項目にアイコンを設定
  - [x] 記事一覧　https://fontawesome.com/icons/list?f=classic&s=solid
  - [x] 記事作成　https://fontawesome.com/icons/pen-to-square?f=classic&s=solid
  - [x] マイページ　https://fontawesome.com/icons/address-card?f=classic&s=solid
  - [x] 自分の記事一覧
  https://fontawesome.com/icons/circle-user?f=classic&s=solid
  https://fontawesome.com/icons/list?f=classic&s=solid
  - [x] お気に入り記事一覧
  https://fontawesome.com/icons/heart?f=classic&s=solid
  https://fontawesome.com/icons/list?f=classic&s=solid
  - [x] お気に入りユーザー一覧
  https://fontawesome.com/icons/heart?f=classic&s=solid
  https://fontawesome.com/icons/users?f=classic&s=solid
  - [x] ログアウト　https://fontawesome.com/icons/right-from-bracket?f=classic&s=solid

- ログイン後のPC版のサイドメニューの以下の項目にアイコンを設定
  - [x] マイページ　https://fontawesome.com/icons/address-card?f=classic&s=solid
  - [x] 自分の記事一覧
  https://fontawesome.com/icons/circle-user?f=classic&s=solid
  https://fontawesome.com/icons/list?f=classic&s=solid
  - [x] お気に入り記事一覧
  https://fontawesome.com/icons/heart?f=classic&s=solid
  https://fontawesome.com/icons/list?f=classic&s=solid
  - [x] お気に入りユーザー一覧
  https://fontawesome.com/icons/heart?f=classic&s=solid
  https://fontawesome.com/icons/users?f=classic&s=solid
  - [x] ログアウト　https://fontawesome.com/icons/right-from-bracket?f=classic&s=solid

- ログイン前のスマホ版のサイドメニューの以下の項目にアイコンを設定（ログイン前のPC版にはサイドバーは存在しない）
  - [x] 記事一覧　https://fontawesome.com/icons/list?f=classic&s=solid
  - [x] ログイン　https://fontawesome.com/icons/right-to-bracket?f=classic&s=solid
  - [x] 新規作成　https://fontawesome.com/icons/user-plus?f=classic&s=solid

- トップページの以下の項目にアイコンを設定
  - [x] プロフィールの項目（「マイページ」と同じアイコン）　https://fontawesome.com/icons/address-card?f=classic&s=regular
  - [x] 推しの登録
  - [x] 記事の作成（「記事作成」と同じアイコン）

## その他
- 通知一覧のデザインを修正。通知のカードを薄青に変更。

## 関連issue
#224 