### PR TITLE
フラッシュメッセージの微調整

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
-  add_flash_types :success, :danger
+  add_flash_types :info, :success, :danger
 
   private
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -183,16 +183,16 @@ class ArticlesController < ApplicationController
 
     if params[:unpublished].present?
       @article.status = :unpublished
-      success_message = "非公開にしました。"
+      info_message = "非公開にしました。"
       redirect_path = my_articles_profile_path(current_user.profile)
     else
       @article.status = :published
-      success_message = "投稿を更新しました。"
+      info_message = "投稿を更新しました。"
       redirect_path = articles_path
     end
 
     if @article.update(article_params)
-      redirect_to redirect_path, success: success_message
+      redirect_to redirect_path, info: info_message
     else
       flash.now[:danger] = "記事を更新できませんでした"
       render :edit, status: :unprocessable_entity

--- a/app/controllers/oshi_details_controller.rb
+++ b/app/controllers/oshi_details_controller.rb
@@ -19,10 +19,10 @@ class OshiDetailsController < ApplicationController
     @oshi_detail.oshi_name = oshi_name if oshi_name
   
     if @oshi_detail.save
-      flash[:success] = "推し情報を更新しました"
+      flash[:success] = "推し情報を作成しました"
       redirect_to profile_path(current_user.profile)
     else
-      flash.now[:danger] = "推し情報を更新できませんでした"
+      flash.now[:danger] = "推し作成できませんでした"
       render :new, status: :unprocessable_entity
     end
   end
@@ -43,7 +43,7 @@ class OshiDetailsController < ApplicationController
     
     # OshiDetail を更新
     if @oshi_detail.update(oshi_detail_params)
-      flash[:success] = "推し情報を更新しました"
+      flash[:info] = "推し情報を更新しました"
       redirect_to profile_path(current_user.profile)
     else
       flash.now[:danger] = "推し情報を更新できませんでした"

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -22,7 +22,7 @@ class ProfilesController < ApplicationController
   def update
     if @profile.update(profile_params)
       @profile.user.update(name: params[:profile][:name]) # nameカラムの更新
-      flash[:success] = "プロフィールを更新しました"
+      flash[:info] = "プロフィールを更新しました"
       redirect_to profile_path
     else
       flash.now[:danger] = "プロフィールを更新できませんでした"

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -17,7 +17,7 @@ class UserSessionsController < ApplicationController
 
   def destroy
     logout
-    flash[:success] = "ログアウトしました"
+    flash[:info] = "ログアウトしました"
     redirect_to root_path, status: :see_other
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def flash_class(level)
     case level
-    when 'notice' then 'bg-blue-500 text-white p-4 rounded'
+    when 'info' then 'bg-orange-300 text-white p-4 rounded'
     when 'success' then 'bg-green-300 text-white p-4 rounded'
     when 'danger' then 'bg-red-300 text-white p-4 rounded'
     when 'alert' then 'bg-yellow-500 text-white p-4 rounded'

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -119,7 +119,7 @@
         <%= f.label :visible_gender, class: "block mb-2" %>
 
         <!-- 推し名に関する説明ボタン -->
-        <label for="gender_modal" class="ml-2 mb-2 hover:bg-gray-300"><i class="fa-regular fa-circle-question"></i></label>
+        <label for="gender_modal" class="ml-1 mb-2 hover:bg-gray-300"><i class="fa-regular fa-circle-question"></i></label>
         <!-- Put this part before </body> tag -->
         <input type="checkbox" id="gender_modal" class="modal-toggle" />
         <div class="modal" role="dialog">
@@ -142,7 +142,7 @@
         <%= f.label :visible_oshi, class: "block mb-3" %>
 
         <!-- 推し名に関する説明ボタン -->
-        <label for="oshiname_check_modal" class="ml-2 mb-3 hover:bg-gray-300"><i class="fa-regular fa-circle-question"></i></label>
+        <label for="oshiname_check_modal" class="ml-1 mb-3 hover:bg-gray-300"><i class="fa-regular fa-circle-question"></i></label>
         <!-- Put this part before </body> tag -->
         <input type="checkbox" id="oshiname_check_modal" class="modal-toggle" />
         <div class="modal" role="dialog">

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -166,7 +166,7 @@
   <div class="mx-auto flex justify-center text-center mb-10">
     <%= f.submit "公開", id: 'publishButton', name: 'published', class: 'btn btn-neutral mr-10' %>
     <%= f.submit "非公開で保存", id: 'unpublishButton', name: 'unpublished', class: "btn btn-neutral mr-10" %>
-    <%= link_to "戻る", articles_path, data: { turbo_method: :get, turbo_confirm: "記事は保存されていませんが、よろしいでしょうか？" }, class: 'btn btn-neutral' %>
+    <%= link_to "戻る", articles_path, data: { turbo_method: :get, turbo_confirm: "記事は保存されませんが、よろしいでしょうか？" }, class: 'btn btn-neutral' %>
   </div>
 
 <% end %>

--- a/app/views/oshi_details/_form.html.erb
+++ b/app/views/oshi_details/_form.html.erb
@@ -42,5 +42,5 @@
 
 <div class="mx-auto flex justify-center text-center mb-10">
   <%= f.submit "登録", class: 'btn btn-neutral mr-10' %>
-  <%= link_to "戻る", profile_path(current_user.profile), class: 'btn btn-neutral ml-5' %>
+  <%= link_to "戻る", profile_path(current_user.profile), data: { turbo_method: :get, turbo_confirm: "推し情報は保存されませんが、よろしいでしょうか？" }, class: 'btn btn-neutral ml-5' %>
 </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -36,7 +36,7 @@
 
         <div class="mx-auto flex justify-center text-center mb-10">
           <%= f.submit "登録", class: 'btn btn-neutral mr-10' %>
-          <%= link_to "戻る", profile_path, class: 'btn btn-neutral mb-10 ml-5' %>
+          <%= link_to "戻る", profile_path, data: { turbo_method: :get, turbo_confirm: "プロフィールは更新されませんが、よろしいでしょうか？" }, class: 'btn btn-neutral mb-10 ml-5' %>
         </div>
         <% end %>
     </div>


### PR DESCRIPTION
## 概要
フラッシュメッセージの出し分けを微調整

## 実装内容
- [x] application_helper.rbのフラッシュメッセージのinfoの色をオレンジに変更

- [x] ログアウトのフラッシュメッセージをinfo（オレンジ）に変更。

- [x] 記事更新のフラッシュメッセージをinfo（オレンジ）に変更。

- [x] 記事の非公開保存のフラッシュメッセージをinfo（オレンジ）に変更。

- [x] プロフィールの更新のフラッシュメッセージをinfo（オレンジ）に変更。

- [x] 推し詳細の更新のフラッシュメッセージをinfo（オレンジ）に変更。

## 追加実装
- [x] 記事編集のフォームの確認ダイアログのメッセージを編集

- [x] プロフィール編集の戻るボタンを押した時に、確認ダイアログが出るように設定

- [x] 推し情報のフォームの戻るボタンを押した時に、確認ダイアログが出るように設定

- [x] 記事フォームの文字の微調整