### PR TITLE
タイトルが動的に変更されるように設定

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,9 @@ module ApplicationHelper
     else 'bg-gray-500 text-white p-4 rounded'
     end
   end
+
+  def page_title(title = '')
+    base_title = '推しOPEN'
+    title.present? ? "#{title} | #{base_title}" : base_title
+  end
 end

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "記事編集") %>
+
 <div class="container mx-auto px-8">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-2xl">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "記事一覧") %>
+
 <div class="container mx-auto px-4">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-3xl">

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "記事作成") %>
+
 <div class="container mx-auto px-8">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-2xl">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, @article.title) %>
+
 <div class="container mx-auto px-4">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-3xl">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Myapp</title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "コメント通知一覧") %>
+
 <div class="container mx-auto px-4">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-3xl">

--- a/app/views/oshi_details/edit.html.erb
+++ b/app/views/oshi_details/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "推し編集") %>
+
 <div class="container mx-auto px-8">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-2xl">

--- a/app/views/oshi_details/new.html.erb
+++ b/app/views/oshi_details/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "推し登録") %>
+
 <div class="container mx-auto px-8">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-2xl">

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "パスワードリセット") %>
+
 <div class="container mx-auto px-8">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-md">

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "パスワードリセット") %>
+
 <div class="container mx-auto px-8">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-md">

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "プロフィール編集") %>
+
 <div class="container mx-auto px-8">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-2xl">

--- a/app/views/profiles/favorite_articles.html.erb
+++ b/app/views/profiles/favorite_articles.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, @profile.user.name + "お気に入り記事一覧") %>
+
 <div class="container mx-auto px-4">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-3xl">

--- a/app/views/profiles/follow_users.html.erb
+++ b/app/views/profiles/follow_users.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, @profile.user.name + "お気に入りユーザー一覧") %>
+
 <div class="container mx-auto px-4">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-3xl">

--- a/app/views/profiles/my_articles.html.erb
+++ b/app/views/profiles/my_articles.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, @profile.user.name + "記事一覧") %>
+
 <div class="container mx-auto px-4">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-3xl">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, @profile.user.name + "プロフィール") %>
+
 <div class="container mx-auto px-4">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-3xl">

--- a/app/views/static_pages/policy.html.erb
+++ b/app/views/static_pages/policy.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "プライバシーポリシー") %>
+
 <div class="container mx-auto px-4">
   <div class="flex justify-center">
     <div class="w-full max-w-5xl">

--- a/app/views/static_pages/term.html.erb
+++ b/app/views/static_pages/term.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "利用規約") %>
+
 <div class="container mx-auto px-4">
   <div class="flex justify-center">
     <div class="w-full max-w-5xl">

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "ログイン") %>
+
 <div class="container mx-auto px-8">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-md">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:title, "新規作成") %>
+
 <div class="container mx-auto px-8">
   <div class="flex justify-center mt-8">
     <div class="w-full max-w-md">


### PR DESCRIPTION
# 概要
タイトルがページによって動的に設定されるようにする

## 実装内容
- [x] application_helper.rbに通常（トップページ）は「推しOPEN」と表示されるように設定。

- [x] 各ページは「"それぞれのページ名" | 推しOPEN」と表示されるように設定。

- [x] それぞれのページにcontent_forメソッドでタイトルをつける。(articles/new.html.erbでは「記事一覧」など) 

- ページ名を単純な名前にしないページは下記のように設定。
  - [x] profiles/show.html.erb　「"ユーザー名"プロフィール」
  - [x] profiles/my_articles.html.erb　「"ユーザー名"記事一覧」
  - [x] profiles/favorite_articles.html.erb　「"ユーザー名"お気に入り記事一覧」
  - [x] profiles/follow_users.html.erb　「"ユーザー名"お気に入りユーザー一覧」
 